### PR TITLE
Better FreeBSD support

### DIFF
--- a/env.example
+++ b/env.example
@@ -2,8 +2,9 @@
 # Example Windows: C:\Users\YourUser\AppData\Roaming\navidrome\navidrome.db
 # Example Linux: /var/lib/navidrome/navidrome.db
 # Example Docker: /path/to/your/navidrome/data/navidrome.db
+# Example FreeBSD: /var/db/navidrome/navidrome.db
 NAVIDROME_DB_PATH=Z:/navidrome/navidrome.db
-NAVIDROME_URL=http://192.168.0.50:4533
+NAVIDROME_URL=http://127.0.0.1:4533
 
 # Optional: Pre-select a Navidrome user ID to skip the interactive prompt when multiple users exist
 # The full user ID string from your Navidrome database (e.g. KDu0PyEFp2fsMkkivAbCeE)

--- a/start.sh
+++ b/start.sh
@@ -1,14 +1,33 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # NaviSync launcher script for Linux/Unix systems
 
+PYTHON=""
+PIP=""
+
+# Check for needed tools
+if which python3 > /dev/null; then
+    PYTHON="python3"
+elif which python > /dev/null; then
+    PYTHON="python"
+else
+    echo "[ERROR] python3/python not found in PATH"
+    exit 1
+fi
+if which pip > /dev/null; then
+    PIP="pip"
+else
+    echo "[ERROR] pip not found in PATH"
+    exit 1
+fi
+
 echo "[INFO] NaviSync Launcher"
-echo "======================"
+echo "========================"
 
 # Check if virtual environment exists
 if [ ! -f ".venv/bin/python" ]; then
     echo "[INFO] Creating virtual environment..."
-    python3 -m venv .venv
+    "${PYTHON}" -m venv .venv
 fi
 
 # Activate the virtual environment  
@@ -17,18 +36,18 @@ source .venv/bin/activate
 
 # Install only missing dependencies
 echo "[INFO] Checking dependencies..."
-pip install --quiet --requirement requirements.txt
+"${PIP}" install --quiet --requirement requirements.txt
 
 # Run the diagnostic check first
 echo "[INFO] Running diagnostic check..."
-python check_setup.py
+"${PYTHON}" check_setup.py
 
 echo ""
 read -p "Press Enter to continue with NaviSync, or Ctrl+C to exit..."
 
 # Run the main script
 echo "[INFO] Running NaviSync..."
-python main.py
+"${PYTHON}" main.py
 
 echo ""
 echo "[INFO] Done! Press Enter to exit..."


### PR DESCRIPTION
* No hardcoded /bin/bash, instead use bash from PATH because bash is in /usr/local/bin/bash on FreeBSD
* Check for python and pip executables in PATH
* Use http://127.0.0.1:4533 as default URL because NaviSync is run on Navidrome host anyways (db access)
* 